### PR TITLE
PSM - HidePSMDrives

### DIFF
--- a/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
+++ b/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
@@ -679,7 +679,7 @@ Function HidePSMDrives
 			# Define the HKEY_USERS root as a new drive
 			New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS -Scope Global
 			# Get a list of all User SID to check
-			$arrRegUsers = Get-ChildItem -Path HKU:\ -ErrorAction Ignore | Select-Object Name -Erro
+			$arrRegUsers = Get-ChildItem -Path HKU:\ -ErrorAction Ignore | Select-Object Name -Error
 
 			ForEach($user in $arrRegUsers)
 			{

--- a/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
+++ b/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
@@ -679,11 +679,11 @@ Function HidePSMDrives
 			# Define the HKEY_USERS root as a new drive
 			New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS -Scope Global
 			# Get a list of all User SID to check
-			$arrRegUsers = Get-ChildItem -Path HKU:\ -ErrorAction Ignore | Select-Object Name -Error
+			$arrRegUsers = Get-ChildItem -Path HKU:\ -ErrorAction Ignore | Select-Object Name -ErrorAction Ignore
 
 			ForEach($user in $arrRegUsers)
 			{
-				$userSID = $user.Replace("HKEY_USERS\","")
+				$userSID = $user.Name.Replace("HKEY_USERS\","")
 				Write-LogMessage -Type Debug -Msg "Checking NoDrives for user $userSID..."
 				# Check PSM Local drives configuration
 				$regNoDrives = @{

--- a/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
+++ b/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
@@ -716,7 +716,7 @@ Function HidePSMDrives
 		}
 	}
 	End {
-
+		Remove-PSDrive -Name HKU
 	}
 }
 

--- a/CYBRHardeningCheck/bin/CommonUtil.psm1
+++ b/CYBRHardeningCheck/bin/CommonUtil.psm1
@@ -209,7 +209,7 @@ Function Get-Reg
 #>
 	param(
 		[Parameter(Mandatory=$true)]
-		[ValidateSet("HKLM:","LocalMachine", "Users", "CurrentUser")]
+		[ValidateSet("HKLM:","LocalMachine", "HKU:", "Users", "CurrentUser")]
 		[String]$Hive,
 		[Parameter(Mandatory=$true)]
 		[String]$Key,


### PR DESCRIPTION
The HidePSMDrives function was failing due to a number of issues:

- An invalid ErrorAction
- The Get-Reg validation list not including the PSDrive name that was being used to map HKEY_USERS.

In addition, I added a cleanup process to HidePSMDrives to un-map the HKU PSDrive to prevent an error if the script was run multiple times.