### PR TITLE
Remove NIC name check for "Ethernet"

### DIFF
--- a/CYBRHardeningCheck/Vault/VaultHardeningSteps.psm1
+++ b/CYBRHardeningCheck/Vault/VaultHardeningSteps.psm1
@@ -103,7 +103,7 @@ Function Vault_StaticIP
 	Process {
 		try{
 			Write-LogMessage -Type Info -Msg "Start verify Vault has static IP"
-			$getdhcpstatus = Get-NetIPAddress -InterfaceAlias "Ethernet" -AddressFamily IPv4
+			$getdhcpstatus = Get-NetIPAddress -AddressFamily IPv4
 			ForEach ($item in $getdhcpstatus)
 			{
 				if ($item.PrefixOrigin -eq "Dhcp")


### PR DESCRIPTION
### What does this PR do?
- Removed the name check for only NICs named "Ethernet"
- We cannot be sure that every Vault environment will use a NIC named "Ethernet" so only checking for this name will not be representative of the environment.
- The report will still show a 'warning' message for any NICs that are configured with DHCP, even if there is a valid NIC with a static address.

### What ticket does this PR close?
Resolves #8

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
