### PR TITLE
Vault Script - Report states in Domain for non-domain joined Vault

### DIFF
--- a/CYBRHardeningCheck/bin/CommonUtil.psm1
+++ b/CYBRHardeningCheck/bin/CommonUtil.psm1
@@ -948,7 +948,7 @@ Function Test-InDomain
 	Begin {}
 	Process{
 		try{
-			return $(Get-WMIItem -Class "Win32_ComputerSystem" -Item "PartOfDomain" -RemoteComputer $machineName)
+			return $(Get-WMIItem -Class "Win32_ComputerSystem" -Item "PartOfDomain" -RemoteComputer $machineName).PartOfDomain
 		}
 		catch{
 			Write-LogMessage -Type Error -Msg "Failed to check if the machine is a domain member. Error: $(Join-ExceptionMessage $_.Exception)"


### PR DESCRIPTION
### What does this PR do?
- When testing whether a server is domain joined, return the correct value from the WMI call

### What ticket does this PR close?
Resolves #16

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
