### PR TITLE
Made PSM AppLocker checks more specific

### DIFF
--- a/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
+++ b/CYBRHardeningCheck/PSM/PSMHardeningSteps.psm1
@@ -463,7 +463,7 @@ Function RunAppLocker
 						$psmAppLockerConfig = $xmlPSM_AppLockerConfig.PSMAppLockerConfiguration.SelectNodes("//Application[@Type='$type']")
 						$currentAppLockerConfig = $xmlAppLockerConfiguration.SelectSingleNode("//RuleCollection[@Type='$type']")
 						# Check that the configurations are not empty - related to issue #90
-						if(($null -ne $psmAppLockerConfig) -and ($null -ne $currentAppLockerConfig))
+						if(($null -ne $psmAppLockerConfig.Path) -and ($null -ne $currentAppLockerConfig.Conditions.FilePathCondition.Path))
 						{
 							$compareResult = Compare-Object -ReferenceObject $currentAppLockerConfig.Conditions.FilePathCondition.Path -DifferenceObject $psmAppLockerConfig.Path
 							If ($compareResult.Count -gt 0)


### PR DESCRIPTION
### Implemented Changes

- Made null check for AppLocker configuration more specific to avoid issue if null reference object in compare

### Connected Issue/Story

Resolves #90
