### PR TITLE
Update VaultHardeningSteps.psm1 - keys validation bug fix

### DIFF
--- a/CYBRHardeningCheck/Vault/VaultHardeningSteps.psm1
+++ b/CYBRHardeningCheck/Vault/VaultHardeningSteps.psm1
@@ -682,7 +682,7 @@ Function Vault_KeysProtection
 			$vaultFolder = $(Get-DetectedComponents -Component Vault).Path
 			$DBParmFile = $(Get-ChildItem -Path $vaultFolder -Include "DBParm.ini" -Recurse).FullName
 			# Get the location of all Vault Keys
-			$keysList = $(Get-Content -Path $DBParmFile | Select-String -List "RecoveryPubKey", "ServerKey", "ServerPrivateKey", "RecoveryPrvKey", "BackupKey").Line
+			$keysList = $(Get-Content -Path $DBParmFile | Select-String -List "^RecoveryPubKey", "^ServerKey", "^ServerPrivateKey", "^RecoveryPrvKey", "^BackupKey").Line
 			Write-LogMessage -Type Verbose -Msg "Found the following Keys paths: $($KeysList -join '; ')"
 			$KeysLocations = @()
 			# Get the Operator CD relevant keys and files path


### PR DESCRIPTION
### Desired Outcome

if DPParm.ini has parameters examples commented out script will not skip checking that

PR related to bug report 101
https://github.com/cyberark/CYBRHardeningCheck/issues/101


I fixed the search to look for the parameters from the line beginning only

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
